### PR TITLE
[FIX][16.0][contract] Change from @onchange to @computed

### DIFF
--- a/contract/models/abstract_contract.py
+++ b/contract/models/abstract_contract.py
@@ -80,20 +80,3 @@ class ContractAbstractContract(models.AbstractModel):
                 contract.journal_id = journal.id
             else:
                 contract.journal_id = None
-
-    @api.onchange(
-        "date_start",
-        "date_end",
-        "recurring_interval",
-        "recurring_rule_type",
-        "recurring_invoicing_type",
-    )
-    def _onchange_recurrency_fields(self):
-        if self.contract_line_fixed_ids:
-            self.contract_line_fixed_ids.date_start = self.date_start
-            self.contract_line_fixed_ids.date_end = self.date_end
-            self.contract_line_fixed_ids.recurring_interval = self.recurring_interval
-            self.contract_line_fixed_ids.recurring_rule_type = self.recurring_rule_type
-            self.contract_line_fixed_ids.recurring_invoicing_type = (
-                self.recurring_invoicing_type
-            )

--- a/contract/models/contract.py
+++ b/contract/models/contract.py
@@ -195,6 +195,25 @@ class ContractContract(models.Model):
                     )
                 modification_ids_not_sent.write({"sent": True})
 
+    @api.depends(
+        "date_start",
+        "date_end",
+        "recurring_interval",
+        "recurring_rule_type",
+        "recurring_invoicing_type",
+        "contract_line_fixed_ids",
+    )
+    def _compute_recurrency_fields(self):
+        for contract in self:
+            for line in contract.contract_line_fixed_ids:
+                line.date_start = contract.date_start
+                line.date_end = contract.date_end
+                line.recurring_interval = contract.recurring_interval
+                line.recurring_rule_type = contract.recurring_rule_type
+                line.recurring_invoicing_type = (
+                    contract.recurring_invoicing_type
+                )
+
     def _compute_access_url(self):
         for record in self:
             record.access_url = "/my/contracts/{}".format(record.id)


### PR DESCRIPTION
@onchange is replaced with the @computed field and the logic is moved to the contract.contract model.

Solution to the problem mentioned in https://github.com/OCA/contract/pull/1080
